### PR TITLE
[fix]#1 質問数が10件のときに「次へ」ボタンが出てしまう不具合を修正

### DIFF
--- a/client/pages/admin/index.vue
+++ b/client/pages/admin/index.vue
@@ -51,7 +51,7 @@ export default {
   },
 
   mounted() {
-    let max = Math.floor( (this.question_list.length + 10) / 10)
+    let max = Math.floor( (this.question_list.length + 9) / 10)
     let d_list = [];
     for(let i = 0; i < max; i++) {
       let j = this.question_list.slice(i * 10, (i * 10) + 10)
@@ -71,7 +71,7 @@ export default {
 
   methods: {
     judgePaginationStyle: function() {
-      if(this.max_row == 1) {
+      if(this.max_row == 0 || this.max_row == 1) {
         this.pagination_style = 'none'
       }
       else if(this.current == 1) {

--- a/client/pages/index.vue
+++ b/client/pages/index.vue
@@ -52,7 +52,7 @@ export default {
   },
 
   mounted() {
-    let max = Math.floor( (this.question_list.length + 10) / 10)
+    let max = Math.floor( (this.question_list.length + 9) / 10)
     let d_list = [];
     for(let i = 0; i < max; i++) {
       let j = this.question_list.slice(i * 10, (i * 10) + 10)
@@ -72,7 +72,7 @@ export default {
 
   methods: {
     judgePaginationStyle: function() {
-      if(this.max_row == 1) {
+      if(this.max_row == 0 || this.max_row == 1) {
         this.pagination_style = 'none'
       }
       else if(this.current == 1) {


### PR DESCRIPTION
ページネーションの最大ページ数の計算方法を修正

- 変更前
(配列の要素数 + 10) / 2 して、小数点以下を切り捨て

- 変更後
(配列の要素数 + 9) / 2 して、小数点以下を切り捨て
さらに、「次へ」ボタンが出てこない条件を最大ページ数が0と1のときにした（配列の要素数が0件のときの対策）